### PR TITLE
Add 'token' credential type to DominoAccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcl-software/domino-rest-sdk-node",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "NodeJS library to interact with a HCL Domino compatible REST API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/samples/Tutorials on Domino Access/create_domino_access_type_token.js
+++ b/samples/Tutorials on Domino Access/create_domino_access_type_token.js
@@ -1,0 +1,23 @@
+/* ========================================================================== *
+ * Copyright (C) 2024 HCL America Inc.                                        *
+ * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
+ * ========================================================================== */
+
+const { DominoAccess } = require('@hcl-software/domino-rest-sdk-node');
+
+/* Initialize a DominoAccess object using an access token. Needs credentials
+ * type to be set to 'token'. */
+
+const accessParams = {
+  baseUrl: 'https://sample.server.com',
+  credentials: {
+    type: 'token',
+    token: 'tokentokentoken',
+  },
+};
+
+const dominoAccess = new DominoAccess(accessParams);
+
+// This object will throw a TokenError if the token is empty or invalid.
+// You can reupdate the token by calling updateCredentials method.
+// dominoAccess.updateCredentials(<new params with the updated token>);

--- a/samples/Tutorials on Domino Server/get_operation_details.js
+++ b/samples/Tutorials on Domino Server/get_operation_details.js
@@ -1,5 +1,5 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2024 HCL America Inc.                                        *
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
@@ -7,12 +7,11 @@
  * This comes pretty handy when you want to check out the parameters for an
  * operation. */
 
-const { DominoAccess, DominoServer } = require('@hcl-software/domino-rest-sdk-node');
+const { DominoServer } = require('@hcl-software/domino-rest-sdk-node');
 const { getCredentials } = require('../resources/credentials');
 
 const start = async () => {
-  const dominoAccess = new DominoAccess(getCredentials());
-  const dominoServer = await DominoServer.getServer(dominoAccess.baseUrl);
+  const dominoServer = await DominoServer.getServer(getCredentials().baseUrl);
   // Let's try to get one operation under setup API.
   const dominoConnector = await dominoServer.getDominoConnector('setup');
 

--- a/src/errors/TokenError.ts
+++ b/src/errors/TokenError.ts
@@ -1,0 +1,15 @@
+/* ========================================================================== *
+ * Copyright (C) 2024 HCL America Inc.                                        *
+ * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
+ * ========================================================================== */
+
+import SdkError from './SdkError';
+
+export class TokenError extends SdkError {
+  constructor() {
+    super(`Access token empty or expired.`);
+    this.name = 'TokenError';
+  }
+}
+
+export default TokenError;

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,8 @@
+/* ========================================================================== *
+ * Copyright (C) 2024 HCL America Inc.                                        *
+ * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
+ * ========================================================================== */
+
 import ApiNotAvailable from './ApiNotAvailable';
 import EmptyParamError from './EmptyParamError';
 import HttpResponseError from './HttpResponseError';
@@ -10,6 +15,7 @@ import NotAnArrayError from './NotAnArrayError';
 import OperationNotAvailable from './OperationNotAvailable';
 import SdkError from './SdkError';
 import TokenDecodeError from './TokenDecodeError';
+import TokenError from './TokenError';
 
 export {
   ApiNotAvailable,
@@ -23,6 +29,7 @@ export {
   NotAnArrayError,
   OperationNotAvailable,
   SdkError,
-  TokenDecodeError
+  TokenDecodeError,
+  TokenError,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2024 HCL America Inc.                                        *
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
@@ -63,6 +63,7 @@ import {
   OperationNotAvailable,
   SdkError,
   TokenDecodeError,
+  TokenError,
 } from './errors';
 import { streamSplit, streamToJson, streamToText, streamTransformToJson } from './helpers/StreamHelpers';
 
@@ -135,6 +136,7 @@ export {
   SortShort,
   SortType,
   TokenDecodeError,
+  TokenError,
   UpdateDocumentOptions,
   ViewEntryScopes,
   streamSplit,

--- a/test/JwtHelper.spec.ts
+++ b/test/JwtHelper.spec.ts
@@ -1,11 +1,12 @@
 /* ========================================================================== *
- * Copyright (C) 2023 HCL America Inc.                                        *
+ * Copyright (C) 2024 HCL America Inc.                                        *
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
 import { expect } from 'chai';
 import jwt from 'jsonwebtoken';
 import sinon from 'sinon';
+import { TokenDecodeError } from '../src';
 import { getExpiry, getOauthSampleJWT, getSampleJWT, isJwtExpired } from '../src/JwtHelper';
 import template from '../src/resources/jwtTemplate.json';
 
@@ -49,7 +50,7 @@ describe('JwtHelper', () => {
       const name = 'John Doe';
       const expected = {
         token_type: 'bearer',
-        expires_in: 3000
+        expires_in: 3000,
       };
       const actual = getOauthSampleJWT(name);
 
@@ -79,6 +80,10 @@ describe('JwtHelper', () => {
       );
       expect(typeof actual).to.be.equal('number');
       expect(actual).to.be.greaterThan(0);
+    });
+
+    it('should throw an error if token cannot be decoded', () => {
+      expect(() => getExpiry('asdacascsa')).to.throw(TokenDecodeError, `Can't decode token 'asdacascsa'.`);
     });
   });
 
@@ -122,6 +127,10 @@ describe('JwtHelper', () => {
       const actual = isJwtExpired('');
       expect(typeof actual).to.be.equal('boolean');
       expect(actual).to.be.equal(true);
+    });
+
+    it('should throw an error if token cannot be decoded', () => {
+      expect(() => isJwtExpired('asdacascsa')).to.throw(TokenDecodeError, `Can't decode token 'asdacascsa'.`);
     });
   });
 });


### PR DESCRIPTION
Changes:
- `DominoAccess` can now accept `token` credential type. If credential type is set to `token`, then the user will only need to provide `credentials.token` to `DominoAccess`.

  ```javascript
  const accessParams = {
    baseUrl: 'https://sample.server.com',
    credentials: {
      type: 'token',
      token: 'jwt access token here',
    },
  };
  const dominoAccess = new DominoAccess(accessParams);

  // Whenever you make a request, it will throw a TokenError if the token is empty or invalid.
  // You can reupdate the token by calling updateCredentials method:
  // dominoAccess.updateCredentials(<new params with the updated token>);
  ```
- Update unit tests.
