### PR TITLE
Fix workflow errors when running tests on Node 20.x

### DIFF
--- a/.github/workflows/pr_check.yaml
+++ b/.github/workflows/pr_check.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run test

--- a/test/DominoAccess.spec.ts
+++ b/test/DominoAccess.spec.ts
@@ -235,6 +235,13 @@ describe('DominoAccess', () => {
 
   describe('accessToken', () => {
     let dominoAccess: DominoAccess;
+    let decodeStub: sinon.SinonStub<[token: string, options?: jwt.DecodeOptions | undefined], string | jwt.JwtPayload | null>;
+
+    afterEach(() => {
+      if (decodeStub) {
+        decodeStub.restore();
+      }
+    });
 
     describe(`credentials type is 'basic'`, () => {
       beforeEach(() => {
@@ -320,7 +327,7 @@ describe('DominoAccess', () => {
       });
 
       it('should fetch again for an access token if access token is expired', async () => {
-        const decodeStub = sinon.stub(jwt, 'decode');
+        decodeStub = sinon.stub(jwt, 'decode');
         decodeStub.returns({ exp: 1694529248 });
         fetchStub.onSecondCall().resolves(new Response(JSON.stringify(sampleJWT)));
 
@@ -331,7 +338,6 @@ describe('DominoAccess', () => {
 
         // fetch should only be called once
         expect(fetchStub.getCalls().length).to.equal(2);
-        decodeStub.restore();
       });
 
       it('should throw an error if token is empty after request', async () => {
@@ -408,7 +414,7 @@ describe('DominoAccess', () => {
       });
 
       it('should fetch again for an access token if access token is expired', async () => {
-        const decodeStub = sinon.stub(jwt, 'decode');
+        decodeStub = sinon.stub(jwt, 'decode');
         decodeStub.returns({ exp: 1694529248 });
         fetchStub.onSecondCall().resolves(new Response(JSON.stringify(sampleOauthJWT)));
 
@@ -419,7 +425,6 @@ describe('DominoAccess', () => {
 
         // fetch should only be called once
         expect(fetchStub.getCalls().length).to.equal(2);
-        decodeStub.restore();
       });
 
       it('should throw an error if token is empty after request', async () => {
@@ -462,11 +467,10 @@ describe('DominoAccess', () => {
       });
 
       it('should throw an error if given access token is expired', async () => {
-        const decodeStub = sinon.stub(jwt, 'decode');
+        decodeStub = sinon.stub(jwt, 'decode');
         decodeStub.returns({ exp: 1694529248 });
 
         await expect(dominoAccess.accessToken()).to.be.rejectedWith(TokenError, 'Access token empty or expired.');
-        decodeStub.restore();
       });
 
       it('should throw an error if given access token is empty', async () => {

--- a/test/always.passing.spec.ts
+++ b/test/always.passing.spec.ts
@@ -9,6 +9,10 @@ import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
 
+// https://github.com/sinonjs/sinon/issues/2590
+// Since this test always runs first, we add this here.
+fetch;
+
 describe('These tests', () => {
   it('should always pass', () => {
     expect(1).to.equal(1);


### PR DESCRIPTION
Changes:

- Refactor `jwt.decode` stub restore on `afterEach` so it doesn't affect other tests when its test case fails.
- Fix an issue where fetch can't be stubbed.
- Update PR check workflow Node version to `20.x`.