### PR TITLE
Transition to module type project

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -7,4 +7,5 @@
 module.exports = {
   require: 'ts-node/register',
   spec: ['test/**/*.spec.ts'],
+  loader: 'ts-node/esm',
 };

--- a/fixup.sh
+++ b/fixup.sh
@@ -2,14 +2,18 @@
 # Copyright (C) 2023 HCL America Inc.                                        #
 # Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           #
 # ========================================================================== #
+if [ -d dist/cjs/ ]; then
 cat >dist/cjs/package.json <<!EOF
 {
-    "type": "commonjs"
+  "type": "commonjs"
 }
 !EOF
+fi
 
+if [ -d dist/esm/ ]; then
 cat >dist/esm/package.json <<!EOF
 {
-    "type": "module"
+  "type": "module"
 }
 !EOF
+fi

--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,15 @@
+# ========================================================================== #
+# Copyright (C) 2023 HCL America Inc.                                        #
+# Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           #
+# ========================================================================== #
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hcl-software/domino-rest-sdk-node",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hcl-software/domino-rest-sdk-node",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,15 @@
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
+        "@istanbuljs/esm-loader-hook": "^0.2.0",
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.11",
-        "@types/chai-as-promised": "^7.1.8",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.10.0",
         "@types/sinon": "^17.0.2",
-        "chai": "^4.3.10",
-        "chai-as-promised": "^7.1.1",
+        "chai": "^5.1.0",
+        "chai-promised": "^1.0.2",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "sinon": "^17.0.1",
@@ -215,6 +216,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -451,6 +461,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@istanbuljs/esm-loader-hook": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/esm-loader-hook/-/esm-loader-hook-0.2.0.tgz",
+      "integrity": "sha512-pw8o3zWCen4sgiNJq69Pcl1Og7Bx4WP3ho7py2FLqZ56Hnz812yN2WwdViCx9tn9U5EWtzF4aqHDRnD7vDs92g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.8.7",
+        "@istanbuljs/load-nyc-config": "^1.1.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "babel-plugin-istanbul": "^6.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.12.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -539,6 +565,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "nyc": ">=15"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -671,15 +712,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
       "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
       "dev": true
-    },
-    "node_modules/@types/chai-as-promised": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
-      "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "*"
-      }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.6",
@@ -849,12 +881,53 @@
       "dev": true
     },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/balanced-match": {
@@ -970,9 +1043,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001608",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001608.tgz",
-      "integrity": "sha512-cjUJTQkk9fQlJR2s4HMuPMvTiRggl0rAVMtthQuyOlDWuqHXqN8azLq+pi8B2TjwKJ32diHjUqRIKeFX4z1FoA==",
+      "version": "1.0.30001610",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
+      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
       "dev": true,
       "funding": [
         {
@@ -990,33 +1063,35 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
+      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
       "dev": true,
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+    "node_modules/chai-promised": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chai-promised/-/chai-promised-1.0.2.tgz",
+      "integrity": "sha512-BwEQ7e4tACZfUjO1xaWpLGLUqKcOlclciI1nPXePj+nx/BZM1Ww2qNbzhnGzgGHV9w4jNq+Z4DXzeLRivqxicw==",
       "dev": true,
       "dependencies": {
-        "check-error": "^1.0.2"
+        "chai": "^5.1.0",
+        "check-error": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.10.0"
       },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
+        "chai": ">= 5"
       }
     },
     "node_modules/chalk": {
@@ -1048,15 +1123,12 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
       "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1195,13 +1267,10 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
@@ -1248,9 +1317,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.733",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.733.tgz",
-      "integrity": "sha512-gUI9nhI2iBGF0OaYYLKOaOtliFMl+Bt1rY7VmEjwxOxqoYLub/D9xmduPEhbw2imE6gYkJKhIE5it+KE2ulVxQ==",
+      "version": "1.4.737",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.737.tgz",
+      "integrity": "sha512-QvLTxaLHKdy5YxvixAw/FfHq2eWLUL9KvsPjp0aHK1gI5d3EDuDgITkvj0nFO2c6zUY3ZqVAJQiBYyQP9tQpfw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2003,9 +2072,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
+      "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -2497,12 +2566,12 @@
       "dev": true
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,21 +98,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
@@ -142,15 +127,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -307,77 +283,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/parser": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
@@ -488,80 +393,6 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
       },
       "engines": {
         "node": ">=8"
@@ -823,18 +654,15 @@
       "dev": true
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "color-convert": "^1.9.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/anymatch": {
@@ -875,10 +703,13 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -903,31 +734,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/balanced-match": {
@@ -1095,31 +901,17 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/check-error": {
@@ -1179,21 +971,18 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/commondir": {
@@ -1209,9 +998,9 @@
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/create-require": {
@@ -1250,12 +1039,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
@@ -1317,9 +1100,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.737",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.737.tgz",
-      "integrity": "sha512-QvLTxaLHKdy5YxvixAw/FfHq2eWLUL9KvsPjp0aHK1gI5d3EDuDgITkvj0nFO2c6zUY3ZqVAJQiBYyQP9tQpfw==",
+      "version": "1.4.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.738.tgz",
+      "integrity": "sha512-lwKft2CLFztD+vEIpesrOtCrko/TFnEJlHFdRhazU7Y/jx5qc4cqsocfVrBg4So4gGe9lvxnbLIoev47WMpg+A==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1344,15 +1127,12 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/esprima": {
@@ -1398,19 +1178,16 @@
       }
     },
     "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^6.0.0",
+        "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/flat": {
@@ -1567,12 +1344,12 @@
       "dev": true
     },
     "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/hasha": {
@@ -1791,27 +1568,19 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.7.5",
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/istanbul-lib-processinfo": {
@@ -1845,6 +1614,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-lib-report/node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -1860,6 +1650,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1871,6 +1676,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/istanbul-lib-report/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
@@ -1906,12 +1717,13 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -1968,6 +1780,36 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jsonwebtoken/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -1994,18 +1836,15 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^5.0.0"
+        "p-locate": "^4.1.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/lodash.flattendeep": {
@@ -2071,6 +1910,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
@@ -2108,15 +2017,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -2205,10 +2105,131 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/ms": {
+    "node_modules/mocha/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nise": {
       "version": "5.1.9",
@@ -2291,6 +2312,21 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/nyc/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/nyc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2312,18 +2348,29 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/nyc/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+    "node_modules/nyc/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=7.0.0"
       }
+    },
+    "node_modules/nyc/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/nyc/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/nyc/node_modules/glob": {
       "version": "7.2.3",
@@ -2345,13 +2392,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/nyc/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+    "node_modules/nyc/node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=8"
@@ -2367,33 +2417,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/nyc/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/nyc/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
@@ -2461,33 +2484,30 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "p-try": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "p-limit": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/p-map": {
@@ -2599,58 +2619,6 @@
       "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
       },
       "engines": {
         "node": ">=8"
@@ -2819,34 +2787,13 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -2927,6 +2874,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sinon/node_modules/supports-color": {
@@ -3031,18 +2987,15 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3495,6 +3448,39 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hcl-software/domino-rest-sdk-node",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "NodeJS library to interact with a HCL Domino compatible REST API",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hcl-software/domino-rest-sdk-node",
   "version": "0.1.6",
+  "type": "module",
   "description": "NodeJS library to interact with a HCL Domino compatible REST API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +17,7 @@
     "build": "tsc",
     "prepublish": "npm run build && npm run test",
     "start": "node .",
-    "test": "nyc --reporter=html --reporter=text mocha",
+    "test": "NODE_OPTIONS='--experimental-loader=@istanbuljs/esm-loader-hook --no-warnings=ExperimentalWarning' nyc --reporter=html --reporter=text mocha",
     "doc": "typedoc"
   },
   "repository": {
@@ -39,14 +40,15 @@
   },
   "homepage": "https://github.com/HCL-TECH-SOFTWARE/domino-rest-sdk-node#readme",
   "devDependencies": {
+    "@istanbuljs/esm-loader-hook": "^0.2.0",
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^4.3.11",
-    "@types/chai-as-promised": "^7.1.8",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.10.0",
     "@types/sinon": "^17.0.2",
-    "chai": "^4.3.10",
-    "chai-as-promised": "^7.1.1",
+    "chai": "^5.1.0",
+    "chai-promised": "^1.0.2",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "sinon": "^17.0.1",
@@ -57,5 +59,14 @@
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.2"
+  },
+  "nyc": {
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "include": [
+      "src/**/*.ts"
+    ],
+    "exclude": [
+      "**/index.ts"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,15 @@
   "version": "0.1.7",
   "type": "module",
   "description": "NodeJS library to interact with a HCL Domino compatible REST API",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "private": false,
   "engines": {
     "node": ">20.0.0"
@@ -14,7 +21,7 @@
   ],
   "scripts": {
     "dev": "ts-node-dev --respawn --pretty --transpile-only src/index.ts",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.esm.json & tsc --project tsconfig.cjs.json & ./fixup.sh",
     "prepublish": "npm run build && npm run test",
     "start": "node .",
     "test": "NODE_OPTIONS='--experimental-loader=@istanbuljs/esm-loader-hook --no-warnings=ExperimentalWarning' nyc --reporter=html --reporter=text mocha",

--- a/samples/Tutorials on Domino Operations/Basis/01_How_To_CRUD_on_Documents/03_GetDocument.js
+++ b/samples/Tutorials on Domino Operations/Basis/01_How_To_CRUD_on_Documents/03_GetDocument.js
@@ -16,7 +16,7 @@ const start = async () => {
   const dbs = await getDominoBasisSession();
 
   await dbs
-    .getDocument('customersdb', '3431740DA895807B00258A3E004C1755', options)
+    .getDocument('customersdb', 'FC9670AE0A33E92185258B020057390D', options)
     .then((response) => console.log(JSON.stringify(response.toJson(), null, 2)))
     .catch((err) => console.log(err.message));
 };

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hcl-software/domino-rest-sdk-node": "../dist"
+        "@hcl-software/domino-rest-sdk-node": "../dist/cjs"
       },
       "engines": {
         "node": ">18.0.0"
       }
     },
-    "../dist": {},
+    "../dist/cjs": {},
     "node_modules/@hcl-software/domino-rest-sdk-node": {
-      "resolved": "../dist",
+      "resolved": "../dist/cjs",
       "link": true
     }
   }

--- a/samples/package.json
+++ b/samples/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"These are samples, no tests.\" && exit 1"
   },
   "dependencies": {
-    "@hcl-software/domino-rest-sdk-node": "../dist"
+    "@hcl-software/domino-rest-sdk-node": "../dist/cjs"
   },
   "keywords": [
     "domino",

--- a/src/DominoAccess.ts
+++ b/src/DominoAccess.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { getExpiry, isJwtExpired } from './JwtHelper.ts';
-import { DominoRestAccess } from './RestInterfaces.ts';
-import { CallbackError, EmptyParamError, HttpResponseError, MissingBearerError, MissingParamError, TokenError } from './errors/index.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { getExpiry, isJwtExpired } from './JwtHelper.js';
+import { DominoRestAccess } from './RestInterfaces.js';
+import { CallbackError, EmptyParamError, HttpResponseError, MissingBearerError, MissingParamError, TokenError } from './errors/index.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 /**
  * Credentials needed to access Domino REST API server. Required properties changes depending

--- a/src/DominoAccess.ts
+++ b/src/DominoAccess.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { getExpiry, isJwtExpired } from './JwtHelper';
-import { DominoRestAccess } from './RestInterfaces';
-import { CallbackError, EmptyParamError, HttpResponseError, MissingBearerError, MissingParamError, TokenError } from './errors';
-import { isEmpty } from './helpers/Utilities';
+import { getExpiry, isJwtExpired } from './JwtHelper.ts';
+import { DominoRestAccess } from './RestInterfaces.ts';
+import { CallbackError, EmptyParamError, HttpResponseError, MissingBearerError, MissingParamError, TokenError } from './errors/index.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 /**
  * Credentials needed to access Domino REST API server. Required properties changes depending

--- a/src/DominoBasisSession.ts
+++ b/src/DominoBasisSession.ts
@@ -22,11 +22,11 @@ import {
   QueryActions,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from '.';
-import DominoConnector from './DominoConnector';
-import DominoDocument from './DominoDocument';
-import DominoListViewOperations from './DominoListViewOperations';
-import { DominoBasisRestSession } from './RestInterfaces';
+} from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import DominoDocument from './DominoDocument.ts';
+import DominoListViewOperations from './DominoListViewOperations.ts';
+import { DominoBasisRestSession } from './RestInterfaces.ts';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/DominoBasisSession.ts
+++ b/src/DominoBasisSession.ts
@@ -22,11 +22,11 @@ import {
   QueryActions,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import DominoDocument from './DominoDocument.ts';
-import DominoListViewOperations from './DominoListViewOperations.ts';
-import { DominoBasisRestSession } from './RestInterfaces.ts';
+} from './index.js';
+import DominoConnector from './DominoConnector.js';
+import DominoDocument from './DominoDocument.js';
+import DominoListViewOperations from './DominoListViewOperations.js';
+import { DominoBasisRestSession } from './RestInterfaces.js';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/DominoConnector.ts
+++ b/src/DominoConnector.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoApiMeta } from './index.ts';
-import { DominoRestConnector } from './RestInterfaces.ts';
-import { HttpResponseError, MissingParamError, OperationNotAvailable } from './errors/index.ts';
+import { DominoAccess, DominoApiMeta } from './index.js';
+import { DominoRestConnector } from './RestInterfaces.js';
+import { HttpResponseError, MissingParamError, OperationNotAvailable } from './errors/index.js';
 
 /**
  * All information needed to read a method

--- a/src/DominoConnector.ts
+++ b/src/DominoConnector.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoApiMeta } from '.';
-import { DominoRestConnector } from './RestInterfaces';
-import { HttpResponseError, MissingParamError, OperationNotAvailable } from './errors';
+import { DominoAccess, DominoApiMeta } from './index.ts';
+import { DominoRestConnector } from './RestInterfaces.ts';
+import { HttpResponseError, MissingParamError, OperationNotAvailable } from './errors/index.ts';
 
 /**
  * All information needed to read a method

--- a/src/DominoDocument.ts
+++ b/src/DominoDocument.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoRestDocument } from './RestInterfaces';
-import { EmptyParamError, MissingParamError } from './errors';
-import { isEmpty } from './helpers/Utilities';
+import { DominoRestDocument } from './RestInterfaces.ts';
+import { EmptyParamError, MissingParamError } from './errors/index.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 /**
  * Base properties of a document.

--- a/src/DominoDocument.ts
+++ b/src/DominoDocument.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoRestDocument } from './RestInterfaces.ts';
-import { EmptyParamError, MissingParamError } from './errors/index.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { DominoRestDocument } from './RestInterfaces.js';
+import { EmptyParamError, MissingParamError } from './errors/index.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 /**
  * Base properties of a document.

--- a/src/DominoDocumentOperations.ts
+++ b/src/DominoDocumentOperations.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DocumentBody, DocumentJSON, DominoAccess, DominoRequestOptions } from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import DominoDocument from './DominoDocument.ts';
-import { EmptyParamError, HttpResponseError, InvalidParamError, NoResponseBody, NotAnArrayError } from './errors/index.ts';
-import { streamToJson } from './helpers/StreamHelpers.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { DocumentBody, DocumentJSON, DominoAccess, DominoRequestOptions } from './index.js';
+import DominoConnector from './DominoConnector.js';
+import DominoDocument from './DominoDocument.js';
+import { EmptyParamError, HttpResponseError, InvalidParamError, NoResponseBody, NotAnArrayError } from './errors/index.js';
+import { streamToJson } from './helpers/StreamHelpers.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 /**
  * A response for document operations that can return document's status after operation.

--- a/src/DominoDocumentOperations.ts
+++ b/src/DominoDocumentOperations.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DocumentBody, DocumentJSON, DominoAccess, DominoRequestOptions } from '.';
-import DominoConnector from './DominoConnector';
-import DominoDocument from './DominoDocument';
-import { EmptyParamError, HttpResponseError, InvalidParamError, NoResponseBody, NotAnArrayError } from './errors';
-import { streamToJson } from './helpers/StreamHelpers';
-import { isEmpty } from './helpers/Utilities';
+import { DocumentBody, DocumentJSON, DominoAccess, DominoRequestOptions } from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import DominoDocument from './DominoDocument.ts';
+import { EmptyParamError, HttpResponseError, InvalidParamError, NoResponseBody, NotAnArrayError } from './errors/index.ts';
+import { streamToJson } from './helpers/StreamHelpers.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 /**
  * A response for document operations that can return document's status after operation.

--- a/src/DominoListView.ts
+++ b/src/DominoListView.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { ListType } from '.';
-import { DominoRestListView } from './RestInterfaces';
-import { EmptyParamError, MissingParamError, NotAnArrayError } from './errors';
-import { isEmpty } from './helpers/Utilities';
+import { ListType } from './index.ts';
+import { DominoRestListView } from './RestInterfaces.ts';
+import { EmptyParamError, MissingParamError, NotAnArrayError } from './errors/index.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 export type DesignColumnSimple = {
   name: string;

--- a/src/DominoListView.ts
+++ b/src/DominoListView.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { ListType } from './index.ts';
-import { DominoRestListView } from './RestInterfaces.ts';
-import { EmptyParamError, MissingParamError, NotAnArrayError } from './errors/index.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { ListType } from './index.js';
+import { DominoRestListView } from './RestInterfaces.js';
+import { EmptyParamError, MissingParamError, NotAnArrayError } from './errors/index.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 export type DesignColumnSimple = {
   name: string;

--- a/src/DominoListViewEntry.ts
+++ b/src/DominoListViewEntry.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoRestListViewEntry } from './RestInterfaces';
+import { DominoRestListViewEntry } from './RestInterfaces.ts';
 
 export type DominoBaseListViewEntry = {
   '@unid': string;

--- a/src/DominoListViewEntry.ts
+++ b/src/DominoListViewEntry.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoRestListViewEntry } from './RestInterfaces.ts';
+import { DominoRestListViewEntry } from './RestInterfaces.js';
 
 export type DominoBaseListViewEntry = {
   '@unid': string;

--- a/src/DominoListViewOperations.ts
+++ b/src/DominoListViewOperations.ts
@@ -3,14 +3,14 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DesignColumnSimple, DocumentBody, DominoAccess, DominoRequestOptions, ListViewBody, ListViewEntryJSON, RichTextRepresentation } from '.';
-import DominoConnector from './DominoConnector';
-import DominoDocument from './DominoDocument';
-import DominoListView from './DominoListView';
-import DominoListViewEntry from './DominoListViewEntry';
-import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors';
-import { streamToJson } from './helpers/StreamHelpers';
-import { isEmpty } from './helpers/Utilities';
+import { DesignColumnSimple, DocumentBody, DominoAccess, DominoRequestOptions, ListViewBody, ListViewEntryJSON, RichTextRepresentation } from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import DominoDocument from './DominoDocument.ts';
+import DominoListView from './DominoListView.ts';
+import DominoListViewEntry from './DominoListViewEntry.ts';
+import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.ts';
+import { streamToJson } from './helpers/StreamHelpers.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 export type GetListViewDesignJSON = {
   '@name': string;

--- a/src/DominoListViewOperations.ts
+++ b/src/DominoListViewOperations.ts
@@ -3,14 +3,14 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DesignColumnSimple, DocumentBody, DominoAccess, DominoRequestOptions, ListViewBody, ListViewEntryJSON, RichTextRepresentation } from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import DominoDocument from './DominoDocument.ts';
-import DominoListView from './DominoListView.ts';
-import DominoListViewEntry from './DominoListViewEntry.ts';
-import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.ts';
-import { streamToJson } from './helpers/StreamHelpers.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { DesignColumnSimple, DocumentBody, DominoAccess, DominoRequestOptions, ListViewBody, ListViewEntryJSON, RichTextRepresentation } from './index.js';
+import DominoConnector from './DominoConnector.js';
+import DominoDocument from './DominoDocument.js';
+import DominoListView from './DominoListView.js';
+import DominoListViewEntry from './DominoListViewEntry.js';
+import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.js';
+import { streamToJson } from './helpers/StreamHelpers.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 export type GetListViewDesignJSON = {
   '@name': string;

--- a/src/DominoScope.ts
+++ b/src/DominoScope.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoBaseDocument, DominoDocumentMeta } from '.';
-import { DominoRestScope } from './RestInterfaces';
-import { EmptyParamError, MissingParamError } from './errors';
-import { isEmpty } from './helpers/Utilities';
+import { DominoBaseDocument, DominoDocumentMeta } from './index.ts';
+import { DominoRestScope } from './RestInterfaces.ts';
+import { EmptyParamError, MissingParamError } from './errors/index.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 /**
  * Domino REST API scope base properties.

--- a/src/DominoScope.ts
+++ b/src/DominoScope.ts
@@ -3,10 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoBaseDocument, DominoDocumentMeta } from './index.ts';
-import { DominoRestScope } from './RestInterfaces.ts';
-import { EmptyParamError, MissingParamError } from './errors/index.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { DominoBaseDocument, DominoDocumentMeta } from './index.js';
+import { DominoRestScope } from './RestInterfaces.js';
+import { EmptyParamError, MissingParamError } from './errors/index.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 /**
  * Domino REST API scope base properties.

--- a/src/DominoScopeOperations.ts
+++ b/src/DominoScopeOperations.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoRequestOptions, ScopeBody } from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import DominoScope from './DominoScope.ts';
-import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.ts';
-import { streamToJson } from './helpers/StreamHelpers.ts';
-import { isEmpty } from './helpers/Utilities.ts';
+import { DominoAccess, DominoRequestOptions, ScopeBody } from './index.js';
+import DominoConnector from './DominoConnector.js';
+import DominoScope from './DominoScope.js';
+import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.js';
+import { streamToJson } from './helpers/StreamHelpers.js';
+import { isEmpty } from './helpers/Utilities.js';
 
 /**
  * API call helper functions for scope operations.

--- a/src/DominoScopeOperations.ts
+++ b/src/DominoScopeOperations.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoRequestOptions, ScopeBody } from '.';
-import DominoConnector from './DominoConnector';
-import DominoScope from './DominoScope';
-import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors';
-import { streamToJson } from './helpers/StreamHelpers';
-import { isEmpty } from './helpers/Utilities';
+import { DominoAccess, DominoRequestOptions, ScopeBody } from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import DominoScope from './DominoScope.ts';
+import { EmptyParamError, HttpResponseError, NoResponseBody } from './errors/index.ts';
+import { streamToJson } from './helpers/StreamHelpers.ts';
+import { isEmpty } from './helpers/Utilities.ts';
 
 /**
  * API call helper functions for scope operations.

--- a/src/DominoServer.ts
+++ b/src/DominoServer.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import DominoConnector from './DominoConnector.ts';
-import { DominoRestServer } from './RestInterfaces.ts';
-import { ApiNotAvailable } from './errors/index.ts';
+import DominoConnector from './DominoConnector.js';
+import { DominoRestServer } from './RestInterfaces.js';
+import { ApiNotAvailable } from './errors/index.js';
 
 /**
  * Data structure returned by the /api endpoint describing the available OpenAPI endpoints.

--- a/src/DominoServer.ts
+++ b/src/DominoServer.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import DominoConnector from './DominoConnector';
-import { DominoRestServer } from './RestInterfaces';
-import { ApiNotAvailable } from './errors';
+import DominoConnector from './DominoConnector.ts';
+import { DominoRestServer } from './RestInterfaces.ts';
+import { ApiNotAvailable } from './errors/index.ts';
 
 /**
  * Data structure returned by the /api endpoint describing the available OpenAPI endpoints.

--- a/src/DominoSetupSession.ts
+++ b/src/DominoSetupSession.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DesignOptions, DominoAccess, DominoServer, ListViewBody, ScopeBody } from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import DominoListViewOperations from './DominoListViewOperations.ts';
-import DominoScope from './DominoScope.ts';
-import DominoScopeOperations from './DominoScopeOperations.ts';
-import { DominoSetupRestSession } from './RestInterfaces.ts';
+import { DesignOptions, DominoAccess, DominoServer, ListViewBody, ScopeBody } from './index.js';
+import DominoConnector from './DominoConnector.js';
+import DominoListViewOperations from './DominoListViewOperations.js';
+import DominoScope from './DominoScope.js';
+import DominoScopeOperations from './DominoScopeOperations.js';
+import { DominoSetupRestSession } from './RestInterfaces.js';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/DominoSetupSession.ts
+++ b/src/DominoSetupSession.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DesignOptions, DominoAccess, DominoServer, ListViewBody, ScopeBody } from '.';
-import DominoConnector from './DominoConnector';
-import DominoListViewOperations from './DominoListViewOperations';
-import DominoScope from './DominoScope';
-import DominoScopeOperations from './DominoScopeOperations';
-import { DominoSetupRestSession } from './RestInterfaces';
+import { DesignOptions, DominoAccess, DominoServer, ListViewBody, ScopeBody } from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import DominoListViewOperations from './DominoListViewOperations.ts';
+import DominoScope from './DominoScope.ts';
+import DominoScopeOperations from './DominoScopeOperations.ts';
+import { DominoSetupRestSession } from './RestInterfaces.ts';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/DominoUserSession.ts
+++ b/src/DominoUserSession.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoRequestOptions, HttpResponseError, NoResponseBody, streamSplit, streamToJson, streamTransformToJson } from '.';
-import DominoConnector from './DominoConnector';
-import { DominoUserRestSession } from './RestInterfaces';
+import { DominoAccess, DominoRequestOptions, HttpResponseError, NoResponseBody, streamSplit, streamToJson, streamTransformToJson } from './index.ts';
+import DominoConnector from './DominoConnector.ts';
+import { DominoUserRestSession } from './RestInterfaces.ts';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/DominoUserSession.ts
+++ b/src/DominoUserSession.ts
@@ -3,9 +3,9 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { DominoAccess, DominoRequestOptions, HttpResponseError, NoResponseBody, streamSplit, streamToJson, streamTransformToJson } from './index.ts';
-import DominoConnector from './DominoConnector.ts';
-import { DominoUserRestSession } from './RestInterfaces.ts';
+import { DominoAccess, DominoRequestOptions, HttpResponseError, NoResponseBody, streamSplit, streamToJson, streamTransformToJson } from './index.js';
+import DominoConnector from './DominoConnector.js';
+import { DominoUserRestSession } from './RestInterfaces.js';
 
 /**
  * Takes in both Domino access and connector, and forms a session wherein a user

--- a/src/JwtHelper.ts
+++ b/src/JwtHelper.ts
@@ -5,7 +5,7 @@
 
 import fs from 'fs';
 import jwt from 'jsonwebtoken';
-import { TokenDecodeError } from './errors/index.ts';
+import { TokenDecodeError } from './errors/index.js';
 // import template from './resources/jwtTemplate.json' assert { type: 'json' };
 
 type SampleJWT = {

--- a/src/JwtHelper.ts
+++ b/src/JwtHelper.ts
@@ -5,8 +5,8 @@
 
 import fs from 'fs';
 import jwt from 'jsonwebtoken';
-import { TokenDecodeError } from './errors';
-import template from './resources/jwtTemplate.json';
+import { TokenDecodeError } from './errors/index.ts';
+// import template from './resources/jwtTemplate.json' assert { type: 'json' };
 
 type SampleJWT = {
   bearer: string;
@@ -26,6 +26,7 @@ type SampleOauthJWT = {
   expires_in: number;
 };
 
+const template = JSON.parse(fs.readFileSync('./src/resources/jwtTemplate.json', 'utf-8'));
 const signOptions: jwt.SignOptions = {
   algorithm: 'RS256',
   expiresIn: `${template.expSeconds}s`,

--- a/src/RestInterfaces.ts
+++ b/src/RestInterfaces.ts
@@ -41,12 +41,12 @@ import {
   ScopeBody,
   ScopeJSON,
   UpdateDocumentOptions,
-} from '.';
-import { streamSplit, streamTransformToJson } from './helpers/StreamHelpers';
-import DominoConnector, { DominoRequestResponse } from './DominoConnector';
-import DominoDocument from './DominoDocument';
-import DominoListViewEntry, { ListViewEntryJSON } from './DominoListViewEntry';
-import DominoScope from './DominoScope';
+} from './index.ts';
+import { streamSplit, streamTransformToJson } from './helpers/StreamHelpers.ts';
+import DominoConnector, { DominoRequestResponse } from './DominoConnector.ts';
+import DominoDocument from './DominoDocument.ts';
+import DominoListViewEntry, { ListViewEntryJSON } from './DominoListViewEntry.ts';
+import DominoScope from './DominoScope.ts';
 
 /* istanbul ignore file */
 /* Interfaces have no testable code - no point including them in coverage reports */

--- a/src/RestInterfaces.ts
+++ b/src/RestInterfaces.ts
@@ -41,12 +41,12 @@ import {
   ScopeBody,
   ScopeJSON,
   UpdateDocumentOptions,
-} from './index.ts';
-import { streamSplit, streamTransformToJson } from './helpers/StreamHelpers.ts';
-import DominoConnector, { DominoRequestResponse } from './DominoConnector.ts';
-import DominoDocument from './DominoDocument.ts';
-import DominoListViewEntry, { ListViewEntryJSON } from './DominoListViewEntry.ts';
-import DominoScope from './DominoScope.ts';
+} from './index.js';
+import { streamSplit, streamTransformToJson } from './helpers/StreamHelpers.js';
+import DominoConnector, { DominoRequestResponse } from './DominoConnector.js';
+import DominoDocument from './DominoDocument.js';
+import DominoListViewEntry, { ListViewEntryJSON } from './DominoListViewEntry.js';
+import DominoScope from './DominoScope.js';
 
 /* istanbul ignore file */
 /* Interfaces have no testable code - no point including them in coverage reports */

--- a/src/errors/ApiNotAvailable.ts
+++ b/src/errors/ApiNotAvailable.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class ApiNotAvailable extends SdkError {
   constructor(api: string) {

--- a/src/errors/ApiNotAvailable.ts
+++ b/src/errors/ApiNotAvailable.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class ApiNotAvailable extends SdkError {
   constructor(api: string) {

--- a/src/errors/CallbackError.ts
+++ b/src/errors/CallbackError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class CallbackError extends SdkError {
   constructor(message: string) {

--- a/src/errors/CallbackError.ts
+++ b/src/errors/CallbackError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class CallbackError extends SdkError {
   constructor(message: string) {

--- a/src/errors/EmptyParamError.ts
+++ b/src/errors/EmptyParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { InvalidParamError } from './InvalidParamError';
+import { InvalidParamError } from './InvalidParamError.ts';
 
 export class EmptyParamError extends InvalidParamError {
   constructor(param: string) {

--- a/src/errors/EmptyParamError.ts
+++ b/src/errors/EmptyParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import { InvalidParamError } from './InvalidParamError.ts';
+import { InvalidParamError } from './InvalidParamError.js';
 
 export class EmptyParamError extends InvalidParamError {
   constructor(param: string) {

--- a/src/errors/HttpResponseError.ts
+++ b/src/errors/HttpResponseError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export type ErrorResponse = {
   statusCode: number;

--- a/src/errors/HttpResponseError.ts
+++ b/src/errors/HttpResponseError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export type ErrorResponse = {
   statusCode: number;

--- a/src/errors/InvalidParamError.ts
+++ b/src/errors/InvalidParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class InvalidParamError extends SdkError {
   constructor(param: string, itShould?: string) {

--- a/src/errors/InvalidParamError.ts
+++ b/src/errors/InvalidParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class InvalidParamError extends SdkError {
   constructor(param: string, itShould?: string) {

--- a/src/errors/MissingBearerError.ts
+++ b/src/errors/MissingBearerError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class MissingBearerError extends SdkError {
   constructor() {

--- a/src/errors/MissingBearerError.ts
+++ b/src/errors/MissingBearerError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class MissingBearerError extends SdkError {
   constructor() {

--- a/src/errors/MissingParamError.ts
+++ b/src/errors/MissingParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class MissingParamError extends SdkError {
   constructor(param: string) {

--- a/src/errors/MissingParamError.ts
+++ b/src/errors/MissingParamError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class MissingParamError extends SdkError {
   constructor(param: string) {

--- a/src/errors/NoResponseBody.ts
+++ b/src/errors/NoResponseBody.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class NoResponseBody extends SdkError {
   constructor(operation: string) {

--- a/src/errors/NoResponseBody.ts
+++ b/src/errors/NoResponseBody.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class NoResponseBody extends SdkError {
   constructor(operation: string) {

--- a/src/errors/NotAnArrayError.ts
+++ b/src/errors/NotAnArrayError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import InvalidParamError from './InvalidParamError.ts';
+import InvalidParamError from './InvalidParamError.js';
 
 export class NotAnArrayError extends InvalidParamError {
   constructor(param: string) {

--- a/src/errors/NotAnArrayError.ts
+++ b/src/errors/NotAnArrayError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import InvalidParamError from './InvalidParamError';
+import InvalidParamError from './InvalidParamError.ts';
 
 export class NotAnArrayError extends InvalidParamError {
   constructor(param: string) {

--- a/src/errors/OperationNotAvailable.ts
+++ b/src/errors/OperationNotAvailable.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class OperationNotAvailable extends SdkError {
   constructor(operation: string) {

--- a/src/errors/OperationNotAvailable.ts
+++ b/src/errors/OperationNotAvailable.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class OperationNotAvailable extends SdkError {
   constructor(operation: string) {

--- a/src/errors/TokenDecodeError.ts
+++ b/src/errors/TokenDecodeError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class TokenDecodeError extends SdkError {
   constructor(token: string) {

--- a/src/errors/TokenDecodeError.ts
+++ b/src/errors/TokenDecodeError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class TokenDecodeError extends SdkError {
   constructor(token: string) {

--- a/src/errors/TokenError.ts
+++ b/src/errors/TokenError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError';
+import SdkError from './SdkError.ts';
 
 export class TokenError extends SdkError {
   constructor() {

--- a/src/errors/TokenError.ts
+++ b/src/errors/TokenError.ts
@@ -3,7 +3,7 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import SdkError from './SdkError.ts';
+import SdkError from './SdkError.js';
 
 export class TokenError extends SdkError {
   constructor() {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,19 +3,19 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import ApiNotAvailable from './ApiNotAvailable.ts';
-import EmptyParamError from './EmptyParamError.ts';
-import HttpResponseError from './HttpResponseError.ts';
-import InvalidParamError from './InvalidParamError.ts';
-import MissingParamError from './MissingParamError.ts';
-import MissingBearerError from './MissingBearerError.ts'
-import CallbackError from './CallbackError.ts'
-import NoResponseBody from './NoResponseBody.ts';
-import NotAnArrayError from './NotAnArrayError.ts';
-import OperationNotAvailable from './OperationNotAvailable.ts';
-import SdkError from './SdkError.ts';
-import TokenDecodeError from './TokenDecodeError.ts';
-import TokenError from './TokenError.ts';
+import ApiNotAvailable from './ApiNotAvailable.js';
+import EmptyParamError from './EmptyParamError.js';
+import HttpResponseError from './HttpResponseError.js';
+import InvalidParamError from './InvalidParamError.js';
+import MissingParamError from './MissingParamError.js';
+import MissingBearerError from './MissingBearerError.js';
+import CallbackError from './CallbackError.js';
+import NoResponseBody from './NoResponseBody.js';
+import NotAnArrayError from './NotAnArrayError.js';
+import OperationNotAvailable from './OperationNotAvailable.js';
+import SdkError from './SdkError.js';
+import TokenDecodeError from './TokenDecodeError.js';
+import TokenError from './TokenError.js';
 
 export {
   ApiNotAvailable,
@@ -32,4 +32,3 @@ export {
   TokenDecodeError,
   TokenError,
 };
-

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,19 +3,19 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import ApiNotAvailable from './ApiNotAvailable';
-import EmptyParamError from './EmptyParamError';
-import HttpResponseError from './HttpResponseError';
-import InvalidParamError from './InvalidParamError';
-import MissingParamError from './MissingParamError';
-import MissingBearerError from './MissingBearerError'
-import CallbackError from './CallbackError'
-import NoResponseBody from './NoResponseBody';
-import NotAnArrayError from './NotAnArrayError';
-import OperationNotAvailable from './OperationNotAvailable';
-import SdkError from './SdkError';
-import TokenDecodeError from './TokenDecodeError';
-import TokenError from './TokenError';
+import ApiNotAvailable from './ApiNotAvailable.ts';
+import EmptyParamError from './EmptyParamError.ts';
+import HttpResponseError from './HttpResponseError.ts';
+import InvalidParamError from './InvalidParamError.ts';
+import MissingParamError from './MissingParamError.ts';
+import MissingBearerError from './MissingBearerError.ts'
+import CallbackError from './CallbackError.ts'
+import NoResponseBody from './NoResponseBody.ts';
+import NotAnArrayError from './NotAnArrayError.ts';
+import OperationNotAvailable from './OperationNotAvailable.ts';
+import SdkError from './SdkError.ts';
+import TokenDecodeError from './TokenDecodeError.ts';
+import TokenError from './TokenError.ts';
 
 export {
   ApiNotAvailable,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@
 /* istanbul ignore file */
 /* index have no testable code - no point including them in coverage reports */
 
-import { CredentialType, DominoAccess, DominoRestAccessJSON, RestCredentials } from './DominoAccess';
-import DominoBasisSession from './DominoBasisSession';
-import { DominoRequestOptions, DominoRequestResponse, DominoRestOperation } from './DominoConnector';
-import { DocumentBody, DocumentJSON, DominoBaseDocument, DominoDocumentMeta } from './DominoDocument';
+import { CredentialType, DominoAccess, DominoRestAccessJSON, RestCredentials } from './DominoAccess.ts';
+import DominoBasisSession from './DominoBasisSession.ts';
+import { DominoRequestOptions, DominoRequestResponse, DominoRestOperation } from './DominoConnector.ts';
+import { DocumentBody, DocumentJSON, DominoBaseDocument, DominoDocumentMeta } from './DominoDocument.ts';
 import {
   BulkCreateDocumentsOptions,
   BulkGetDocumentsOptions,
@@ -28,9 +28,9 @@ import {
   QueryDocumentParseResponse,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from './DominoDocumentOperations';
-import { DesignColumnSimple, DominoBaseListView, ListViewBody, SortType } from './DominoListView';
-import { DominoBaseListViewEntry, ListType, ListViewEntryBody, ListViewEntryJSON } from './DominoListViewEntry';
+} from './DominoDocumentOperations.ts';
+import { DesignColumnSimple, DominoBaseListView, ListViewBody, SortType } from './DominoListView.ts';
+import { DominoBaseListViewEntry, ListType, ListViewEntryBody, ListViewEntryJSON } from './DominoListViewEntry.ts';
 import {
   CreateUpdateListResponse,
   DesignOptions,
@@ -45,11 +45,11 @@ import {
   PivotListViewResponse,
   SortShort,
   ViewEntryScopes,
-} from './DominoListViewOperations';
-import { AccessLevel, DominoBaseScope, ScopeBody, ScopeJSON } from './DominoScope';
-import { DominoApiMeta, DominoServer } from './DominoServer';
-import DominoSetupSession from './DominoSetupSession';
-import DominoUserSession from './DominoUserSession';
+} from './DominoListViewOperations.ts';
+import { AccessLevel, DominoBaseScope, ScopeBody, ScopeJSON } from './DominoScope.ts';
+import { DominoApiMeta, DominoServer } from './DominoServer.ts';
+import DominoSetupSession from './DominoSetupSession.ts';
+import DominoUserSession from './DominoUserSession.ts';
 import {
   ApiNotAvailable,
   CallbackError,
@@ -64,8 +64,8 @@ import {
   SdkError,
   TokenDecodeError,
   TokenError,
-} from './errors';
-import { streamSplit, streamToJson, streamToText, streamTransformToJson } from './helpers/StreamHelpers';
+} from './errors/index.ts';
+import { streamSplit, streamToJson, streamToText, streamTransformToJson } from './helpers/StreamHelpers.ts';
 
 export {
   AccessLevel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@
 /* istanbul ignore file */
 /* index have no testable code - no point including them in coverage reports */
 
-import { CredentialType, DominoAccess, DominoRestAccessJSON, RestCredentials } from './DominoAccess.ts';
-import DominoBasisSession from './DominoBasisSession.ts';
-import { DominoRequestOptions, DominoRequestResponse, DominoRestOperation } from './DominoConnector.ts';
-import { DocumentBody, DocumentJSON, DominoBaseDocument, DominoDocumentMeta } from './DominoDocument.ts';
+import { CredentialType, DominoAccess, DominoRestAccessJSON, RestCredentials } from './DominoAccess.js';
+import DominoBasisSession from './DominoBasisSession.js';
+import { DominoRequestOptions, DominoRequestResponse, DominoRestOperation } from './DominoConnector.js';
+import { DocumentBody, DocumentJSON, DominoBaseDocument, DominoDocumentMeta } from './DominoDocument.js';
 import {
   BulkCreateDocumentsOptions,
   BulkGetDocumentsOptions,
@@ -28,9 +28,9 @@ import {
   QueryDocumentParseResponse,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from './DominoDocumentOperations.ts';
-import { DesignColumnSimple, DominoBaseListView, ListViewBody, SortType } from './DominoListView.ts';
-import { DominoBaseListViewEntry, ListType, ListViewEntryBody, ListViewEntryJSON } from './DominoListViewEntry.ts';
+} from './DominoDocumentOperations.js';
+import { DesignColumnSimple, DominoBaseListView, ListViewBody, SortType } from './DominoListView.js';
+import { DominoBaseListViewEntry, ListType, ListViewEntryBody, ListViewEntryJSON } from './DominoListViewEntry.js';
 import {
   CreateUpdateListResponse,
   DesignOptions,
@@ -45,11 +45,11 @@ import {
   PivotListViewResponse,
   SortShort,
   ViewEntryScopes,
-} from './DominoListViewOperations.ts';
-import { AccessLevel, DominoBaseScope, ScopeBody, ScopeJSON } from './DominoScope.ts';
-import { DominoApiMeta, DominoServer } from './DominoServer.ts';
-import DominoSetupSession from './DominoSetupSession.ts';
-import DominoUserSession from './DominoUserSession.ts';
+} from './DominoListViewOperations.js';
+import { AccessLevel, DominoBaseScope, ScopeBody, ScopeJSON } from './DominoScope.js';
+import { DominoApiMeta, DominoServer } from './DominoServer.js';
+import DominoSetupSession from './DominoSetupSession.js';
+import DominoUserSession from './DominoUserSession.js';
 import {
   ApiNotAvailable,
   CallbackError,
@@ -64,8 +64,8 @@ import {
   SdkError,
   TokenDecodeError,
   TokenError,
-} from './errors/index.ts';
-import { streamSplit, streamToJson, streamToText, streamTransformToJson } from './helpers/StreamHelpers.ts';
+} from './errors/index.js';
+import { streamSplit, streamToJson, streamToText, streamTransformToJson } from './helpers/StreamHelpers.js';
 
 export {
   AccessLevel,

--- a/test/DominoAccess.spec.ts
+++ b/test/DominoAccess.spec.ts
@@ -3,8 +3,8 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
 import jwt from 'jsonwebtoken';
 import sinon from 'sinon';
 import {
@@ -18,10 +18,10 @@ import {
   MissingParamError,
   RestCredentials,
   TokenError,
-} from '../src';
-import { getOauthSampleJWT, getSampleJWT } from '../src/JwtHelper';
+} from '../src/index.ts';
+import { getOauthSampleJWT, getSampleJWT } from '../src/JwtHelper.ts';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('DominoAccess', () => {
   const sampleJWT = getSampleJWT('John Doe');

--- a/test/DominoAccess.spec.ts
+++ b/test/DominoAccess.spec.ts
@@ -18,8 +18,8 @@ import {
   MissingParamError,
   RestCredentials,
   TokenError,
-} from '../src/index.ts';
-import { getOauthSampleJWT, getSampleJWT } from '../src/JwtHelper.ts';
+} from '../src/index.js';
+import { getOauthSampleJWT, getSampleJWT } from '../src/JwtHelper.js';
 
 use(chaiAsPromised);
 

--- a/test/DominoBasisSession.spec.ts
+++ b/test/DominoBasisSession.spec.ts
@@ -15,10 +15,10 @@ import {
   DominoServer,
   QueryActions,
   RichTextRepresentation,
-} from '../src';
-import DominoConnector from '../src/DominoConnector';
-import DominoDocument from '../src/DominoDocument';
-import DominoListViewOperations from '../src/DominoListViewOperations';
+} from '../src/index.ts';
+import DominoConnector from '../src/DominoConnector.ts';
+import DominoDocument from '../src/DominoDocument.ts';
+import DominoListViewOperations from '../src/DominoListViewOperations.ts';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/DominoBasisSession.spec.ts
+++ b/test/DominoBasisSession.spec.ts
@@ -15,10 +15,10 @@ import {
   DominoServer,
   QueryActions,
   RichTextRepresentation,
-} from '../src/index.ts';
-import DominoConnector from '../src/DominoConnector.ts';
-import DominoDocument from '../src/DominoDocument.ts';
-import DominoListViewOperations from '../src/DominoListViewOperations.ts';
+} from '../src/index.js';
+import DominoConnector from '../src/DominoConnector.js';
+import DominoDocument from '../src/DominoDocument.js';
+import DominoListViewOperations from '../src/DominoListViewOperations.js';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/DominoConnector.spec.ts
+++ b/test/DominoConnector.spec.ts
@@ -7,8 +7,8 @@ import { expect, use } from 'chai';
 import { chaiAsPromised } from 'chai-promised';
 import fs from 'fs';
 import sinon from 'sinon';
-import { CredentialType, DominoAccess, DominoServer, HttpResponseError, MissingParamError, OperationNotAvailable } from '../src/index.ts';
-import DominoConnector, { DominoRestOperation } from '../src/DominoConnector.ts';
+import { CredentialType, DominoAccess, DominoServer, HttpResponseError, MissingParamError, OperationNotAvailable } from '../src/index.js';
+import DominoConnector, { DominoRestOperation } from '../src/DominoConnector.js';
 
 use(chaiAsPromised);
 

--- a/test/DominoConnector.spec.ts
+++ b/test/DominoConnector.spec.ts
@@ -3,20 +3,20 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
 import fs from 'fs';
 import sinon from 'sinon';
-import { CredentialType, DominoAccess, DominoServer, HttpResponseError, MissingParamError, OperationNotAvailable } from '../src';
-import DominoConnector, { DominoRestOperation } from '../src/DominoConnector';
-import createDocResponse from './resources/DominoDocumentOperations/doc_response.json';
+import { CredentialType, DominoAccess, DominoServer, HttpResponseError, MissingParamError, OperationNotAvailable } from '../src/index.ts';
+import DominoConnector, { DominoRestOperation } from '../src/DominoConnector.ts';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('DominoConnector', () => {
   const sampleUrl = 'http://localhost:8880';
   const baseApi = JSON.parse(fs.readFileSync('./test/resources/openapi.basis.json', 'utf-8'));
   const apiDefinitions = JSON.parse(fs.readFileSync('./test/resources/apidefinitions.json', 'utf-8'));
+  const createDocResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_response.json', 'utf-8'));
   const fakeCredentials = {
     baseUrl: 'somewhere',
     credentials: {

--- a/test/DominoDocument.spec.ts
+++ b/test/DominoDocument.spec.ts
@@ -4,13 +4,15 @@
  * ========================================================================== */
 
 import { expect } from 'chai';
-import { EmptyParamError, MissingParamError } from '../src';
-import DominoDocument from '../src/DominoDocument';
-import doc1 from './resources/DominoDocument/doc1.json';
-import doc2 from './resources/DominoDocument/doc2.json';
-import doc3 from './resources/DominoDocument/doc3.json';
+import fs from 'fs';
+import { EmptyParamError, MissingParamError } from '../src/index.ts';
+import DominoDocument from '../src/DominoDocument.ts';
 
 describe('DominoDocument', () => {
+  const doc1 = JSON.parse(fs.readFileSync('./test/resources/DominoDocument/doc1.json', 'utf-8'));
+  const doc2 = JSON.parse(fs.readFileSync('./test/resources/DominoDocument/doc2.json', 'utf-8'));
+  const doc3 = JSON.parse(fs.readFileSync('./test/resources/DominoDocument/doc3.json', 'utf-8'));
+
   describe('constructor', () => {
     it(`should create a 'DominoDocument' object`, () => {
       const dominoDocument = new DominoDocument(doc1);

--- a/test/DominoDocument.spec.ts
+++ b/test/DominoDocument.spec.ts
@@ -5,8 +5,8 @@
 
 import { expect } from 'chai';
 import fs from 'fs';
-import { EmptyParamError, MissingParamError } from '../src/index.ts';
-import DominoDocument from '../src/DominoDocument.ts';
+import { EmptyParamError, MissingParamError } from '../src/index.js';
+import DominoDocument from '../src/DominoDocument.js';
 
 describe('DominoDocument', () => {
   const doc1 = JSON.parse(fs.readFileSync('./test/resources/DominoDocument/doc1.json', 'utf-8'));

--- a/test/DominoDocumentOperations.spec.ts
+++ b/test/DominoDocumentOperations.spec.ts
@@ -27,10 +27,10 @@ import {
   QueryActions,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from '../src/index.ts';
-import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.ts';
-import DominoDocument from '../src/DominoDocument.ts';
-import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
+} from '../src/index.js';
+import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.js';
+import DominoDocument from '../src/DominoDocument.js';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.js';
 
 describe('DominoDocumentOperations', async () => {
   const doc = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc.json', 'utf-8'));

--- a/test/DominoDocumentOperations.spec.ts
+++ b/test/DominoDocumentOperations.spec.ts
@@ -27,21 +27,21 @@ import {
   QueryActions,
   RichTextRepresentation,
   UpdateDocumentOptions,
-} from '../src';
-import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector';
-import DominoDocument from '../src/DominoDocument';
-import { transformToRequestResponse } from './helpers/transformToRequestResponse';
-import doc from './resources/DominoDocumentOperations/doc.json';
-import docPatchReq from './resources/DominoDocumentOperations/doc_patch_request.json';
-import docPatchResponse from './resources/DominoDocumentOperations/doc_patch_response.json';
-import docResponse from './resources/DominoDocumentOperations/doc_response.json';
-import docUpdateResponse from './resources/DominoDocumentOperations/doc_update_response.json';
-import operationStatusResponse from './resources/DominoDocumentOperations/operation_status_response.json';
-import queryExecuteResponse from './resources/DominoDocumentOperations/query_operation_execute_response.json';
-import queryExplainResponse from './resources/DominoDocumentOperations/query_operation_explain_response.json';
-import queryParseResponse from './resources/DominoDocumentOperations/query_operation_parse_response.json';
+} from '../src/index.ts';
+import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.ts';
+import DominoDocument from '../src/DominoDocument.ts';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
 
 describe('DominoDocumentOperations', async () => {
+  const doc = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc.json', 'utf-8'));
+  const docPatchReq = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_patch_request.json', 'utf-8'));
+  const docPatchResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_patch_response.json', 'utf-8'));
+  const docResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_response.json', 'utf-8'));
+  const docUpdateResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_update_response.json', 'utf-8'));
+  const operationStatusResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/operation_status_response.json', 'utf-8'));
+  const queryExecuteResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/query_operation_execute_response.json', 'utf-8'));
+  const queryExplainResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/query_operation_explain_response.json', 'utf-8'));
+  const queryParseResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/query_operation_parse_response.json', 'utf-8'));
   const baseApi = JSON.parse(fs.readFileSync('./test/resources/openapi.basis.json', 'utf-8'));
   const dataSource = 'dataSource';
   const fakeCredentials = {

--- a/test/DominoListView.spec.ts
+++ b/test/DominoListView.spec.ts
@@ -4,13 +4,15 @@
  * ========================================================================== */
 
 import { expect } from 'chai';
-import { DesignColumnSimple, EmptyParamError, ListType, ListViewBody, MissingParamError, NotAnArrayError } from '../src';
-import DominoListView from '../src/DominoListView';
-import dlv1 from './resources/DominoListView/dlv1_request.json';
-import dlv2NoFormulaCol from './resources/DominoListView/dlv2_incorrectCols_noFormula.json';
-import dlv2NoNameCol from './resources/DominoListView/dlv2_incorrectCols_noName.json';
+import fs from 'fs';
+import { DesignColumnSimple, EmptyParamError, ListType, ListViewBody, MissingParamError, NotAnArrayError } from '../src/index.ts';
+import DominoListView from '../src/DominoListView.ts';
 
 describe('DominoListView', () => {
+  const dlv1 = JSON.parse(fs.readFileSync('./test/resources/DominoListView/dlv1_request.json', 'utf-8'));
+  const dlv2NoFormulaCol = JSON.parse(fs.readFileSync('./test/resources/DominoListView/dlv2_incorrectCols_noFormula.json', 'utf-8'));
+  const dlv2NoNameCol = JSON.parse(fs.readFileSync('./test/resources/DominoListView/dlv2_incorrectCols_noName.json', 'utf-8'));
+
   describe('constructor', () => {
     let listViewBody: ListViewBody;
 

--- a/test/DominoListView.spec.ts
+++ b/test/DominoListView.spec.ts
@@ -5,8 +5,8 @@
 
 import { expect } from 'chai';
 import fs from 'fs';
-import { DesignColumnSimple, EmptyParamError, ListType, ListViewBody, MissingParamError, NotAnArrayError } from '../src/index.ts';
-import DominoListView from '../src/DominoListView.ts';
+import { DesignColumnSimple, EmptyParamError, ListType, ListViewBody, MissingParamError, NotAnArrayError } from '../src/index.js';
+import DominoListView from '../src/DominoListView.js';
 
 describe('DominoListView', () => {
   const dlv1 = JSON.parse(fs.readFileSync('./test/resources/DominoListView/dlv1_request.json', 'utf-8'));

--- a/test/DominoListViewEntry.spec.ts
+++ b/test/DominoListViewEntry.spec.ts
@@ -4,10 +4,12 @@
  * ========================================================================== */
 
 import { expect } from 'chai';
-import DominoListViewEntry from '../src/DominoListViewEntry';
-import lve1 from './resources/DominoListViewEntry/lve1.json';
+import fs from 'fs';
+import DominoListViewEntry from '../src/DominoListViewEntry.ts';
 
 describe('DominoListViewEntry', () => {
+  const lve1 = JSON.parse(fs.readFileSync('./test/resources/DominoListViewEntry/lve1.json', 'utf-8'));
+
   describe('structure', () => {
     describe('name', () => {
       it('should return @unid if it is in the given view entry', () => {

--- a/test/DominoListViewEntry.spec.ts
+++ b/test/DominoListViewEntry.spec.ts
@@ -5,7 +5,7 @@
 
 import { expect } from 'chai';
 import fs from 'fs';
-import DominoListViewEntry from '../src/DominoListViewEntry.ts';
+import DominoListViewEntry from '../src/DominoListViewEntry.js';
 
 describe('DominoListViewEntry', () => {
   const lve1 = JSON.parse(fs.readFileSync('./test/resources/DominoListViewEntry/lve1.json', 'utf-8'));

--- a/test/DominoListViewOperations.spec.ts
+++ b/test/DominoListViewOperations.spec.ts
@@ -1,4 +1,3 @@
-import { transformToRequestResponse } from './helpers/transformToRequestResponse';
 /* ========================================================================== *
  * Copyright (C) 2023 HCL America Inc.                                        *
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
@@ -7,6 +6,10 @@ import { transformToRequestResponse } from './helpers/transformToRequestResponse
 import { expect } from 'chai';
 import fs from 'fs';
 import sinon from 'sinon';
+import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.ts';
+import DominoDocument from '../src/DominoDocument.ts';
+import DominoListView from '../src/DominoListView.ts';
+import DominoListViewOperations from '../src/DominoListViewOperations.ts';
 import {
   CredentialType,
   DesignOptions,
@@ -21,19 +24,16 @@ import {
   ListViewBody,
   NoResponseBody,
   SortType,
-} from '../src';
-import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector';
-import DominoDocument from '../src/DominoDocument';
-import DominoListView from '../src/DominoListView';
-import DominoListViewOperations from '../src/DominoListViewOperations';
-import docResponse from './resources/DominoDocumentOperations/doc_response.json';
-import create_dlv1_response from './resources/DominoListView/create_dlv1_response.json';
-import dlv1_response from './resources/DominoListView/dlv1_response.json';
-import lv1_response from './resources/DominoListView/lv1_response.json';
-import lve1_response from './resources/DominoListView/lve1_response.json';
-import lvpe1_response from './resources/DominoListView/lvpe1_response.json';
+} from '../src/index.ts';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
 
 describe('DominoListViewOperations', async () => {
+  const docResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_response.json', 'utf-8'));
+  const create_dlv1_response = JSON.parse(fs.readFileSync('./test/resources/DominoListView/create_dlv1_response.json', 'utf-8'));
+  const dlv1_response = JSON.parse(fs.readFileSync('./test/resources/DominoListView/dlv1_response.json', 'utf-8'));
+  const lv1_response = JSON.parse(fs.readFileSync('./test/resources/DominoListView/lv1_response.json', 'utf-8'));
+  const lve1_response = JSON.parse(fs.readFileSync('./test/resources/DominoListView/lve1_response.json', 'utf-8'));
+  const lvpe1_response = JSON.parse(fs.readFileSync('./test/resources/DominoListView/lvpe1_response.json', 'utf-8'));
   const baseApi = JSON.parse(fs.readFileSync('./test/resources/openapi.basis.json', 'utf-8'));
   const dataSource = 'demoapi';
   const listViewName = 'Customers';

--- a/test/DominoListViewOperations.spec.ts
+++ b/test/DominoListViewOperations.spec.ts
@@ -6,10 +6,10 @@
 import { expect } from 'chai';
 import fs from 'fs';
 import sinon from 'sinon';
-import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.ts';
-import DominoDocument from '../src/DominoDocument.ts';
-import DominoListView from '../src/DominoListView.ts';
-import DominoListViewOperations from '../src/DominoListViewOperations.ts';
+import DominoConnector, { DominoRequestResponse } from '../src/DominoConnector.js';
+import DominoDocument from '../src/DominoDocument.js';
+import DominoListView from '../src/DominoListView.js';
+import DominoListViewOperations from '../src/DominoListViewOperations.js';
 import {
   CredentialType,
   DesignOptions,
@@ -24,8 +24,8 @@ import {
   ListViewBody,
   NoResponseBody,
   SortType,
-} from '../src/index.ts';
-import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
+} from '../src/index.js';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.js';
 
 describe('DominoListViewOperations', async () => {
   const docResponse = JSON.parse(fs.readFileSync('./test/resources/DominoDocumentOperations/doc_response.json', 'utf-8'));

--- a/test/DominoScope.spec.ts
+++ b/test/DominoScope.spec.ts
@@ -4,13 +4,15 @@
  * ========================================================================== */
 
 import { expect } from 'chai';
-import { AccessLevel, EmptyParamError, MissingParamError } from '../src';
-import DominoScope from '../src/DominoScope';
-import scp1 from './resources/DominoScope/scp1.json';
-import scp2 from './resources/DominoScope/scp2.json';
-import scp3 from './resources/DominoScope/scp3.json';
+import fs from 'fs';
+import { AccessLevel, EmptyParamError, MissingParamError } from '../src/index.ts';
+import DominoScope from '../src/DominoScope.ts';
 
 describe('DominoScope', () => {
+  const scp1 = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scp1.json', 'utf-8'));
+  const scp2 = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scp2.json', 'utf-8'));
+  const scp3 = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scp3.json', 'utf-8'));
+
   describe('constructor', () => {
     let scope: any;
 

--- a/test/DominoScope.spec.ts
+++ b/test/DominoScope.spec.ts
@@ -5,8 +5,8 @@
 
 import { expect } from 'chai';
 import fs from 'fs';
-import { AccessLevel, EmptyParamError, MissingParamError } from '../src/index.ts';
-import DominoScope from '../src/DominoScope.ts';
+import { AccessLevel, EmptyParamError, MissingParamError } from '../src/index.js';
+import DominoScope from '../src/DominoScope.js';
 
 describe('DominoScope', () => {
   const scp1 = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scp1.json', 'utf-8'));

--- a/test/DominoScopeOperations.spec.ts
+++ b/test/DominoScopeOperations.spec.ts
@@ -15,11 +15,11 @@ import {
   EmptyParamError,
   HttpResponseError,
   NoResponseBody,
-} from '../src/index.ts';
-import DominoConnector from '../src/DominoConnector.ts';
-import DominoScope from '../src/DominoScope.ts';
-import DominoScopeOperations from '../src/DominoScopeOperations.ts';
-import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
+} from '../src/index.js';
+import DominoConnector from '../src/DominoConnector.js';
+import DominoScope from '../src/DominoScope.js';
+import DominoScopeOperations from '../src/DominoScopeOperations.js';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.js';
 
 describe('DominoScopeOperations', async () => {
   const scp = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scpJson.json', 'utf-8'));

--- a/test/DominoScopeOperations.spec.ts
+++ b/test/DominoScopeOperations.spec.ts
@@ -15,15 +15,15 @@ import {
   EmptyParamError,
   HttpResponseError,
   NoResponseBody,
-} from '../src';
-import DominoConnector from '../src/DominoConnector';
-import DominoScope from '../src/DominoScope';
-import DominoScopeOperations from '../src/DominoScopeOperations';
-import { transformToRequestResponse } from './helpers/transformToRequestResponse';
-import scp from './resources/DominoScope/scpJson.json';
-import scpResponse from './resources/DominoScope/scp_response.json';
+} from '../src/index.ts';
+import DominoConnector from '../src/DominoConnector.ts';
+import DominoScope from '../src/DominoScope.ts';
+import DominoScopeOperations from '../src/DominoScopeOperations.ts';
+import { transformToRequestResponse } from './helpers/transformToRequestResponse.ts';
 
 describe('DominoScopeOperations', async () => {
+  const scp = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scpJson.json', 'utf-8'));
+  const scpResponse = JSON.parse(fs.readFileSync('./test/resources/DominoScope/scp_response.json', 'utf-8'));
   const baseApi = JSON.parse(fs.readFileSync('./test/resources/openapi.basis.json', 'utf-8'));
   const fakeCredentials = {
     baseUrl: 'somewhere',

--- a/test/DominoServer.spec.ts
+++ b/test/DominoServer.spec.ts
@@ -3,14 +3,14 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
 import fs from 'fs';
 import sinon from 'sinon';
-import { ApiNotAvailable, DominoServer, HttpResponseError } from '../src';
-import DominoConnector from '../src/DominoConnector';
+import { ApiNotAvailable, DominoServer, HttpResponseError } from '../src/index.ts';
+import DominoConnector from '../src/DominoConnector.ts';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('DominoServer', () => {
   const basisApi = JSON.parse(fs.readFileSync('./test/resources/openapi.basis.json', 'utf-8'));

--- a/test/DominoServer.spec.ts
+++ b/test/DominoServer.spec.ts
@@ -7,8 +7,8 @@ import { expect, use } from 'chai';
 import { chaiAsPromised } from 'chai-promised';
 import fs from 'fs';
 import sinon from 'sinon';
-import { ApiNotAvailable, DominoServer, HttpResponseError } from '../src/index.ts';
-import DominoConnector from '../src/DominoConnector.ts';
+import { ApiNotAvailable, DominoServer, HttpResponseError } from '../src/index.js';
+import DominoConnector from '../src/DominoConnector.js';
 
 use(chaiAsPromised);
 

--- a/test/DominoSetupSession.spec.ts
+++ b/test/DominoSetupSession.spec.ts
@@ -6,10 +6,10 @@
 import { expect } from 'chai';
 import fs from 'fs';
 import sinon from 'sinon';
-import { CredentialType, DominoAccess, DominoApiMeta, DominoServer, DominoSetupSession, SortType } from '../src';
-import DominoConnector from '../src/DominoConnector';
-import DominoListViewOperations from '../src/DominoListViewOperations';
-import DominoScopeOperations from '../src/DominoScopeOperations';
+import { CredentialType, DominoAccess, DominoApiMeta, DominoServer, DominoSetupSession, SortType } from '../src/index.ts';
+import DominoConnector from '../src/DominoConnector.ts';
+import DominoListViewOperations from '../src/DominoListViewOperations.ts';
+import DominoScopeOperations from '../src/DominoScopeOperations.ts';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/DominoSetupSession.spec.ts
+++ b/test/DominoSetupSession.spec.ts
@@ -6,10 +6,10 @@
 import { expect } from 'chai';
 import fs from 'fs';
 import sinon from 'sinon';
-import { CredentialType, DominoAccess, DominoApiMeta, DominoServer, DominoSetupSession, SortType } from '../src/index.ts';
-import DominoConnector from '../src/DominoConnector.ts';
-import DominoListViewOperations from '../src/DominoListViewOperations.ts';
-import DominoScopeOperations from '../src/DominoScopeOperations.ts';
+import { CredentialType, DominoAccess, DominoApiMeta, DominoServer, DominoSetupSession, SortType } from '../src/index.js';
+import DominoConnector from '../src/DominoConnector.js';
+import DominoListViewOperations from '../src/DominoListViewOperations.js';
+import DominoScopeOperations from '../src/DominoScopeOperations.js';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/DominoUserSession.spec.ts
+++ b/test/DominoUserSession.spec.ts
@@ -15,8 +15,8 @@ import {
   DominoUserSession,
   HttpResponseError,
   NoResponseBody
-} from '../src/index.ts';
-import DominoConnector from '../src/DominoConnector.ts';
+} from '../src/index.js';
+import DominoConnector from '../src/DominoConnector.js';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/DominoUserSession.spec.ts
+++ b/test/DominoUserSession.spec.ts
@@ -15,8 +15,8 @@ import {
   DominoUserSession,
   HttpResponseError,
   NoResponseBody
-} from '../src';
-import DominoConnector from '../src/DominoConnector';
+} from '../src/index.ts';
+import DominoConnector from '../src/DominoConnector.ts';
 
 const fakeCredentials = {
   baseUrl: 'somewhere',

--- a/test/JwtHelper.spec.ts
+++ b/test/JwtHelper.spec.ts
@@ -7,8 +7,8 @@ import { expect } from 'chai';
 import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import sinon from 'sinon';
-import { TokenDecodeError } from '../src/index.ts';
-import { getExpiry, getOauthSampleJWT, getSampleJWT, isJwtExpired } from '../src/JwtHelper.ts';
+import { TokenDecodeError } from '../src/index.js';
+import { getExpiry, getOauthSampleJWT, getSampleJWT, isJwtExpired } from '../src/JwtHelper.js';
 
 describe('JwtHelper', () => {
   const template = JSON.parse(fs.readFileSync('./src/resources/jwtTemplate.json', 'utf-8'));

--- a/test/JwtHelper.spec.ts
+++ b/test/JwtHelper.spec.ts
@@ -4,13 +4,14 @@
  * ========================================================================== */
 
 import { expect } from 'chai';
+import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import sinon from 'sinon';
-import { TokenDecodeError } from '../src';
-import { getExpiry, getOauthSampleJWT, getSampleJWT, isJwtExpired } from '../src/JwtHelper';
-import template from '../src/resources/jwtTemplate.json';
+import { TokenDecodeError } from '../src/index.ts';
+import { getExpiry, getOauthSampleJWT, getSampleJWT, isJwtExpired } from '../src/JwtHelper.ts';
 
 describe('JwtHelper', () => {
+  const template = JSON.parse(fs.readFileSync('./src/resources/jwtTemplate.json', 'utf-8'));
   let decodeStub: sinon.SinonStub<[token: string, options?: jwt.DecodeOptions | undefined], string | jwt.JwtPayload | null>;
   let fakeClock: sinon.SinonFakeTimers;
 

--- a/test/always.passing.spec.ts
+++ b/test/always.passing.spec.ts
@@ -3,11 +3,10 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import * as chai from 'chai';
-import { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 // https://github.com/sinonjs/sinon/issues/2590
 // Since this test always runs first, we add this here.

--- a/test/helpers/StreamHelpers.spec.ts
+++ b/test/helpers/StreamHelpers.spec.ts
@@ -3,12 +3,11 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import * as chai from 'chai';
-import { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { streamSplit, streamToJson, streamToText, streamTransformToJson } from '../../src';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
+import { streamSplit, streamToJson, streamToText, streamTransformToJson } from '../../src/index.ts';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('Stream conversion test', () => {
   const jsonObj = { color: 'red', shape: 'round' };

--- a/test/helpers/StreamHelpers.spec.ts
+++ b/test/helpers/StreamHelpers.spec.ts
@@ -5,7 +5,7 @@
 
 import { expect, use } from 'chai';
 import { chaiAsPromised } from 'chai-promised';
-import { streamSplit, streamToJson, streamToText, streamTransformToJson } from '../../src/index.ts';
+import { streamSplit, streamToJson, streamToText, streamTransformToJson } from '../../src/index.js';
 
 use(chaiAsPromised);
 

--- a/test/helpers/isEmpty.spec.ts
+++ b/test/helpers/isEmpty.spec.ts
@@ -3,12 +3,11 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import * as chai from 'chai';
-import { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { isEmpty } from '../../src/helpers/Utilities';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
+import { isEmpty } from '../../src/helpers/Utilities.ts';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe('Many ways to be empty', () => {
   it('should have empty arrays', () => {

--- a/test/helpers/isEmpty.spec.ts
+++ b/test/helpers/isEmpty.spec.ts
@@ -5,7 +5,7 @@
 
 import { expect, use } from 'chai';
 import { chaiAsPromised } from 'chai-promised';
-import { isEmpty } from '../../src/helpers/Utilities.ts';
+import { isEmpty } from '../../src/helpers/Utilities.js';
 
 use(chaiAsPromised);
 

--- a/test/helpers/transformToRequestResponse.ts
+++ b/test/helpers/transformToRequestResponse.ts
@@ -1,4 +1,4 @@
-import { DominoRequestResponse } from '../../src/index.ts';
+import { DominoRequestResponse } from '../../src/index.js';
 
 export const transformToRequestResponse = (incoming: any, status?: number): DominoRequestResponse => {
   const stream = incoming !== null && typeof incoming === 'object' ? JSON.stringify(incoming) : incoming;

--- a/test/helpers/transformToRequestResponse.ts
+++ b/test/helpers/transformToRequestResponse.ts
@@ -1,4 +1,4 @@
-import { DominoRequestResponse } from '../../src';
+import { DominoRequestResponse } from '../../src/index.ts';
 
 export const transformToRequestResponse = (incoming: any, status?: number): DominoRequestResponse => {
   const stream = incoming !== null && typeof incoming === 'object' ? JSON.stringify(incoming) : incoming;

--- a/test/sinon.demo.spec.ts
+++ b/test/sinon.demo.spec.ts
@@ -3,12 +3,12 @@
  * Apache-2.0 license   https://www.apache.org/licenses/LICENSE-2.0           *
  * ========================================================================== */
 
-import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { expect, use } from 'chai';
+import { chaiAsPromised } from 'chai-promised';
 import { afterEach } from 'mocha';
 import sinon from 'sinon';
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 const urlToResultMapping = new Map<string, any>();
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,12 +1,7 @@
-/* Configuration for running tests */
+/* Base configuration for CommonJS and ESM */
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "declarationDir": "./out",
-    "outDir": "./out",
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
@@ -21,10 +16,5 @@
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "skipLibCheck": true
-  },
-  "include": ["src/**/*ts", "src/**/*.json"],
-  "exclude": ["node_modules", "**/*spec.ts"],
-  "ts-node": {
-    "files": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,16 @@
+/* Configuration for CommonJS */
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "declarationDir": "./dist/types",
+    "outDir": "./dist/cjs",
+  },
+  "include": ["src/**/*ts", "src/**/*.json"],
+  "exclude": ["node_modules", "**/*spec.ts"],
+  "ts-node": {
+    "files": true
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,17 @@
+/* Configuration for ESM */
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declarationDir": "./dist/types",
+    "outDir": "./dist/esm",
+  },
+  "include": ["src/**/*ts", "src/**/*.json"],
+  "exclude": ["node_modules", "**/*spec.ts"],
+  "ts-node": {
+    "files": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,36 +1,28 @@
 {
-    "compilerOptions": {
-        /* Visit https://aka.ms/tsconfig to read more about this file */
-        "target": "ESNext",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
-        "resolveJsonModule": true,
-        "declaration": true,
-        "declarationMap": true,
-        "sourceMap": true,
-        "outDir": "./dist",
-        "removeComments": false,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "alwaysStrict": true,
-        "noUnusedLocals": true,
-        "noImplicitReturns": true,
-        "skipLibCheck": true,
-        "noEmit": true,
-        "allowImportingTsExtensions": true,
-    },
-    "include": [
-        "src/**/*ts",
-        "src/**/*.json"
-    ],
-    "exclude": [
-        "node_modules",
-        "**/*spec.ts"
-    ],
-    "ts-node": {
-        "files": true
-    }
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "removeComments": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*ts", "src/**/*.json"],
+  "exclude": ["node_modules", "**/*spec.ts"],
+  "ts-node": {
+    "files": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig to read more about this file */
-        "target": "ES2022",
+        "target": "ESNext",
         "module": "NodeNext",
-        "moduleResolution": "nodenext",
+        "moduleResolution": "NodeNext",
         "resolveJsonModule": true,
         "declaration": true,
         "declarationMap": true,
@@ -18,7 +18,9 @@
         "alwaysStrict": true,
         "noUnusedLocals": true,
         "noImplicitReturns": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "noEmit": true,
+        "allowImportingTsExtensions": true,
     },
     "include": [
         "src/**/*ts",


### PR DESCRIPTION
Since Chai 5 is ESM only, we need to update the project to type `module`. This brought a lot of refactors and changes to the code and configuration files.

Along with this change, since this project is now `module` type, when we package this, all `CommonJS` projects that depends on this will get an error, as such part of this change is for becoming a hybrid package, thus supporting both `CommonJS` and `ESM` projects that depend on this.

Changes:
- Change type to `module`.
- Refactor all code to work on `module` type.
- Change `.mocharc` to `cjs` file.
- Update `tsconfig.json`.
- New dev packages to make nyc work: `@istanbuljs/esm-loader-hook` and `@istanbuljs/nyc-config-typescript`.
- Support both `CommonJS` and `ESM` types.

Note:
If you use the Mocha explorer extension in VS Code, you need to add this configuration in `settings.json` to make it work:
```json
"mochaExplorer.nodeArgv": ["--loader=ts-node/esm"]
```